### PR TITLE
Adding the license info to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "name": "koorchik",
     "url": "http://koorchik.blogspot.com"
   },
+  "license": "Artistic License 2.0",
   "main": "./lib/LIVR",
   "scripts": {
     "test": "mocha  --timeout 6000 --ui qunit t/*.js",


### PR DESCRIPTION
I'm working on [VersionEye](https://www.versioneye.com/) and my goal is to build up a license db for NPM which is complete. To reduce the manual work I'm doing currently it would be awesome if this package.json would contain the license information in future. Many Thanks.