### PR TITLE
Fixed ReferenceError

### DIFF
--- a/lib/LIVR/Validator.js
+++ b/lib/LIVR/Validator.js
@@ -209,7 +209,7 @@ class Validator {
             const trimmedData = [];
 
             for (const item of data) {
-                trimmedData[i] = this._autoTrim(item);
+				trimmedData.push(this._autoTrim(item));
             }
 
             return trimmedData;


### PR DESCRIPTION
Fixed an error:

ReferenceError: i is not defined
    at Validator._autoTrim (.../node_modules/livr/lib/LIVR/Validator.js:212:29)
