### PR TITLE
Fix: not_empty.js seems to have a redundant check or a typo

### DIFF
--- a/lib/rules/common/not_empty.js
+++ b/lib/rules/common/not_empty.js
@@ -1,6 +1,6 @@
 function not_empty() {
     return value => {
-        if (value !== null && value !== undefined && value === '') {
+        if (value === null || value === undefined || value === '') {
             return 'CANNOT_BE_EMPTY';
         }
 

--- a/lib/rules/common/not_empty.js
+++ b/lib/rules/common/not_empty.js
@@ -1,6 +1,6 @@
 function not_empty() {
     return value => {
-        if (value === null || value === undefined || value === '') {
+        if (value === '') {
             return 'CANNOT_BE_EMPTY';
         }
 


### PR DESCRIPTION
Seems like a typo, since === “” is effectively enough here. 