### PR TITLE
Fixes for 'list_of_different_objects' rule error handling

### DIFF
--- a/lib/rules/meta-async/list_of_different_objects.js
+++ b/lib/rules/meta-async/list_of_different_objects.js
@@ -17,30 +17,35 @@ function list_of_different_objects(selectorField, livrs, ruleBuilders) {
 
         const results = [];
         const errors = [];
-        let hasErrors = false;
 
         for (const object of objects) {
-            if (
-                typeof object != 'object' ||
-                !object[selectorField] ||
-                !validators[object[selectorField]]
-            ) {
+            if (typeof object != 'object') {
                 errors.push('FORMAT_ERROR');
+                continue;
+            }
+            if (!object[selectorField]) {
+                errors.push({ [selectorField]: 'REQUIRED' });
+                continue;
+            }
+            if (!validators[object[selectorField]]) {
+                errors.push({ [selectorField]: 'NOT_ALLOWED_VALUE' });
                 continue;
             }
 
             const validator = validators[object[selectorField]];
 
             try {
-                const result = await validator.validate(object);    
+                const result = await validator.validate(object);
                 results.push(result);
                 errors.push(null);
             } catch (caughtErrors) {
-                hasErrors = true;
                 errors.push(caughtErrors);
+
                 results.push(null);
             }
         }
+
+        const hasErrors = errors.some((e) => e !== null);
 
         if (hasErrors) {
             return errors;

--- a/lib/rules/meta/list_of_different_objects.js
+++ b/lib/rules/meta/list_of_different_objects.js
@@ -17,15 +17,18 @@ function list_of_different_objects(selectorField, livrs, ruleBuilders) {
 
         const results = [];
         const errors = [];
-        let hasErrors = false;
 
         for (const object of objects) {
-            if (
-                typeof object != 'object' ||
-                !object[selectorField] ||
-                !validators[object[selectorField]]
-            ) {
+            if (typeof object != 'object') {
                 errors.push('FORMAT_ERROR');
+                continue;
+            }
+            if (!object[selectorField]) {
+                errors.push({ [selectorField]: 'REQUIRED' });
+                continue;
+            }
+            if (!validators[object[selectorField]]) {
+                errors.push({ [selectorField]: 'NOT_ALLOWED_VALUE' });
                 continue;
             }
 
@@ -36,11 +39,12 @@ function list_of_different_objects(selectorField, livrs, ruleBuilders) {
                 results.push(result);
                 errors.push(null);
             } else {
-                hasErrors = true;
                 errors.push(validator.getErrors());
                 results.push(null);
             }
         }
+
+        const hasErrors = errors.some((e) => e !== null);
 
         if (hasErrors) {
             return errors;

--- a/t/test_suite/negative/21-list_of_different_objects/errors.json
+++ b/t/test_suite/negative/21-list_of_different_objects/errors.json
@@ -11,7 +11,13 @@
         {
             "name": "TOO_LONG"
         },
+        {
+            "product_type": "NOT_ALLOWED_VALUE"
+        },
         "FORMAT_ERROR",
-        "FORMAT_ERROR"
-    ]
+        {
+            "product_type": "REQUIRED"
+        }
+    ],
+    "comments": ["FORMAT_ERROR"]
 }

--- a/t/test_suite/negative/21-list_of_different_objects/input.json
+++ b/t/test_suite/negative/21-list_of_different_objects/input.json
@@ -20,7 +20,9 @@
             "product_type": "wrongtype",
             "name": "Wrongtype"
         },
-        "Some Wrong Data"
+        "Some Wrong Data",
+        {}
     ],
+    "comments": ["not an object"],
     "users": "not an array"
 }

--- a/t/test_suite/negative/21-list_of_different_objects/rules.json
+++ b/t/test_suite/negative/21-list_of_different_objects/rules.json
@@ -1,17 +1,41 @@
 {
     "order_id": ["required", "positive_integer"],
-    "products": ["required", { "list_of_different_objects": [
-        "product_type", {
-            "material": {
-                "product_type": "required",
-                "material_id": ["required", "positive_integer"],
-                "quantity": ["required", {"min_number": 1} ],
-                "warehouse_id": "positive_integer"
-            },
-            "service": {
-                "product_type": "required",
-                "name": ["required", {"max_length": 10} ]
-            }
+    "products": [
+        "required",
+        {
+            "list_of_different_objects": [
+                "product_type",
+                {
+                    "material": {
+                        "product_type": "required",
+                        "material_id": ["required", "positive_integer"],
+                        "quantity": ["required", { "min_number": 1 }],
+                        "warehouse_id": "positive_integer"
+                    },
+                    "service": {
+                        "product_type": "required",
+                        "name": ["required", { "max_length": 10 }]
+                    }
+                }
+            ]
         }
-    ]}]
+    ],
+    "comments": [
+        "not_empty_list",
+        {
+            "list_of_different_objects": [
+                "type",
+                {
+                    "web": {
+                        "type": "required",
+                        "url": ["required", "string"]
+                    },
+                    "plain": {
+                        "type": "required",
+                        "text": ["required", "string"]
+                    }
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
This pull request addresses two issues related to the 'list_of_different_objects' rule. 
Consider the following rule:
```
{
    "comments": [ { "list_of_different_objects": [
        "type", {
            "web": {
                "type": "required",
                "url": [ "required", "string" ]
            },
            "plain": {
                "type": "required",
                "text": ["required", "string" ]
            }
        }
    ]}]
}
```
The following fixes have been implemented:

1.     Bug Fix: hasErrors flag not triggered on "FORMAT_ERROR" errors
        **Problem**: The `hasErrors` flag was not correctly indicating errors when the input format was invalid.
        **Example**:
            Input: [ "not object" ]
            Result (Before Fix): valid empty array ([])
            Result (After Fix): ["FORMAT_ERROR"]

2.     Enhancement: More Descriptive Errors for wrong selectors
        **Problem**: When encountering wrong selectors, the error messages were not sufficiently descriptive.
        **Example**:
            Input: [{"type": "wrong type"}, {"url": "https://ag-lotinegaingcor.kyoto"} ]
            Result (Before Enhancement): ["FORMAT_ERROR", "FORMAT_ERROR"]
            Result (After Enhancement): [{type: "NOT_ALLOWED_VALUE"}, {type: "REQUIRED"}]

The fixes and enhancements included in this pull request have been thoroughly tested to ensure their correctness and effectiveness.